### PR TITLE
Allow passing custom scopes to endpoints and handle github errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 dist
 package-lock.json
 .nova
+.vscode

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "build": "tsc",
+    "dev": "tsc --watch --pretty --incremental",
     "lint": "tsc --noEmit",
     "prettier": "prettier --write '**/*.{js,json,css,md,ts,tsx}'",
     "preversion": "npm run test -s && npm run build"
@@ -18,12 +19,10 @@
     "node": ">=12"
   },
   "dependencies": {
-    "dedent": "^0.7.0",
     "dotenv": "^8.2.0",
     "simple-oauth2": "^4.2.0"
   },
   "devDependencies": {
-    "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/simple-oauth2": "^4.1.0",

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,54 @@
+export interface GitHubError {
+  error: string
+  error_description?: string
+  error_uri?: string
+}
+
+export function isGitHubError(data: unknown): data is GitHubError {
+  return Boolean(typeof data === 'object' && data && 'error' in data)
+}
+
+export function gitHubErrorToNetlifyError(err: GitHubError) {
+  const message = [
+    `GitHub Error: ${err.error}`,
+    err?.error_description,
+    err?.error_uri,
+  ]
+    .filter(Boolean)
+    .join(' | ')
+  return { message }
+}
+
+export type GitHubScope =
+  | 'repo'
+  | 'repo:status'
+  | 'repo_deployment'
+  | 'public_repo'
+  | 'repo:invite'
+  | 'security_events'
+  | 'admin:repo_hook'
+  | 'write:repo_hook'
+  | 'read:repo_hook'
+  | 'admin:org'
+  | 'write:org'
+  | 'read:org'
+  | 'admin:public_key'
+  | 'write:public_key'
+  | 'read:public_key'
+  | 'admin:org_hook'
+  | 'gist'
+  | 'notifications'
+  | 'user'
+  | 'read:user'
+  | 'user:email'
+  | 'user:follow'
+  | 'delete_repo'
+  | 'write:discussion'
+  | 'read:discussion'
+  | 'write:packages'
+  | 'read:packages'
+  | 'delete:packages'
+  | 'admin:gpg_key'
+  | 'write:gpg_key'
+  | 'read:gpg_key'
+  | 'workflow'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@
 // with the goal of moving to a reusable npm module
 //
 
-import dedent = require('dedent')
-import { NowRequest, NowResponse } from '@vercel/node'
+import { VercelRequest, VercelResponse } from '@vercel/node'
 import { randomBytes } from 'crypto'
 import { AuthorizationCode, ModuleOptions } from 'simple-oauth2'
+import { GitHubScope, isGitHubError, gitHubErrorToNetlifyError } from './github'
 
 const {
   OAUTH_CLIENT_ID = '',
@@ -18,7 +18,7 @@ const {
 
 export const oauthConfig: ModuleOptions = Object.freeze({
   client: Object.freeze({
-    id: OAUTH_CLIENT_ID!,
+    id: OAUTH_CLIENT_ID,
     secret: OAUTH_CLIENT_SECRET,
   }),
   auth: Object.freeze({
@@ -32,90 +32,121 @@ export function randomState() {
   return randomBytes(6).toString('hex')
 }
 
+interface Options {
+  secure?: boolean
+  scopes?: GitHubScope[]
+}
+
+const defaultOptions: Required<Options> = {
+  secure: true,
+  scopes: ['repo', 'user'],
+}
+
 /** Render a html response with a script to finish a client-side github authentication */
 export function renderResponse(status: 'success' | 'error', content: any) {
-  return dedent`
-  <!DOCTYPE html>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8">
-      <title>Authorizing ...</title>
-    </head>
-    <body>
-      <p id="message"></p>
-      <script>
-        // Output a message to the user
-        function sendMessage(message) {
-          document.getElementById("message").innerText = message;
-          document.title = message
-        }
+  return `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Authorizing ...</title>
+  </head>
+  <body>
+    <p id="message"></p>
+    <script>
+      // Output a message to the user
+      function sendMessage(message) {
+        document.getElementById("message").innerText = message;
+        document.title = message
+      }
 
-        // Handle a window message by sending the auth to the "opener"
-        function receiveMessage(message) {
-          console.debug("receiveMessage", message);
-          window.opener.postMessage(
-            'authorization:github:${status}:${JSON.stringify(content)}',
-            message.origin
-          );
-          window.removeEventListener("message", receiveMessage, false);
-          sendMessage("Authorized, closing ...");
-        }
+      // Handle a window message by sending the auth to the "opener"
+      function receiveMessage(message) {
+        console.debug("receiveMessage", message);
+        window.opener.postMessage(
+          'authorization:github:${status}:${JSON.stringify(content)}',
+          message.origin
+        );
+        window.removeEventListener("message", receiveMessage, false);
+        sendMessage("Authorized, closing ...");
+      }
 
-        sendMessage("Authorizing ...");
-        window.addEventListener("message", receiveMessage, false);
+      sendMessage("Authorizing ...");
+      window.addEventListener("message", receiveMessage, false);
 
-        console.debug("postMessage", "authorizing:github", "*")
-        window.opener.postMessage("authorizing:github", "*");
-      </script>
-    </body>
-  </html>
-  `
+      console.debug("postMessage", "authorizing:github", "*")
+      window.opener.postMessage("authorizing:github", "*");
+    </script>
+  </body>
+</html>
+  `.trim()
 }
 
 /** An endpoint to start an OAuth2 authentication */
-export function auth(req: NowRequest, res: NowResponse) {
-  const { host } = req.headers
+export const getAuth = (options: Options = {}) =>
+  function auth(req: VercelRequest, res: VercelResponse) {
+    const protocol = options.secure ?? defaultOptions.secure ? 'https' : 'http'
+    const scope = (options.scopes ?? defaultOptions.scopes).join(',')
 
-  console.debug('auth host=%o', host)
-
-  const authorizationCode = new AuthorizationCode(oauthConfig)
-
-  const url = authorizationCode.authorizeURL({
-    redirect_uri: `https://${host}/api/callback`,
-    scope: `repo,user`,
-    state: randomState(),
-  })
-
-  res.writeHead(301, { Location: url })
-  res.end()
-}
-
-/** An endpoint to finish an OAuth2 authentication */
-export async function callback(req: NowRequest, res: NowResponse) {
-  try {
-    const code = req.query.code as string
     const { host } = req.headers
+
+    console.debug('auth host=%o', host)
 
     const authorizationCode = new AuthorizationCode(oauthConfig)
 
-    const accessToken = await authorizationCode.getToken({
-      code,
-      redirect_uri: `https://${host}/api/callback`,
+    const url = authorizationCode.authorizeURL({
+      redirect_uri: `${protocol}://${host}/api/callback`,
+      scope,
+      state: randomState(),
     })
 
-    console.debug('callback host=%o', host)
-
-    const { token } = authorizationCode.createToken(accessToken)
-    
-    res.setHeader('Content-Type', 'text/html');
-
-    res.status(200).send(
-      renderResponse('success', {
-        token: token.token.access_token,
-        provider: 'github',
-      })
-    )
-  } catch (e) {
-    res.status(200).send(renderResponse('error', e))
+    res.writeHead(301, { Location: url })
+    res.end()
   }
-}
+export const auth = getAuth()
+
+/** An endpoint to finish an OAuth2 authentication */
+export const getCallback = (options: Options = {}) =>
+  async function callback(req: VercelRequest, res: VercelResponse) {
+    const protocol = options.secure ?? defaultOptions.secure ? 'https' : 'http'
+
+    try {
+      if (isGitHubError(req.query)) {
+        throw gitHubErrorToNetlifyError(req.query)
+      }
+
+      const code = req.query.code as string
+      const { host } = req.headers
+
+      const authorizationCode = new AuthorizationCode(oauthConfig)
+
+      const accessToken = await authorizationCode.getToken({
+        code,
+        redirect_uri: `${protocol}://${host}/api/callback`,
+      })
+
+      if (isGitHubError(accessToken.token)) {
+        throw gitHubErrorToNetlifyError(accessToken.token)
+      }
+
+      console.debug('callback host=%o', host)
+
+      const { token } = authorizationCode.createToken(accessToken)
+
+      if (isGitHubError(token)) {
+        throw gitHubErrorToNetlifyError(token)
+      }
+
+      res.setHeader('Content-Type', 'text/html')
+      res.status(200).send(
+        renderResponse('success', {
+          token: token.token.access_token,
+          provider: 'github',
+        })
+      )
+    } catch (e) {
+      res.setHeader('Content-Type', 'text/html')
+      res.status(200).send(renderResponse('error', e))
+    }
+  }
+export const callback = getCallback()


### PR DESCRIPTION
This PR:
- [x] adds `getAuth` and `getCallback` functions which can be used to customise `auth` and `callback` handlers' behaviour
- [x] allows for specifying options:
  - [x] `secure` in order to enable/disable https in the callback endpoint URL (`true` by default)
  - [x] `scopes` to allow passing custom scopes to GitHub API (`['repo', 'user']` by default)
- [x] adds `isGitHubError` and `gitHubErrorToNetlifyError` functions to handle previously unhandled GitHub API errors
- [x] adds `npm run dev` command for easier testing